### PR TITLE
Upgrade to **autonomous** CEv1,

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Our team heavily uses Github for all of our software management. We use Github i
 
 If you find an issue, please do file it on the repository.
 
-We love examples for addressing issues - issues with a Plunkr, [jsFiddle](http://jsfiddle.net), or [jsBin](http://jsbin.com) will be much easier for us to work on quickly. You can start with [this jsbin](http://jsbin.com/capequ/edit?html,output) which sets up the basics to demonstrate a Juicy element.
+We love examples for addressing issues - issues with a Plunkr, [jsFiddle](http://jsfiddle.net), or [jsBin](http://jsbin.com) will be much easier for us to work on quickly. You can start with [this jsbin](http://jsbin.com/capequ/edit?html,output) which sets up the basics to demonstrate a Palindrom element.
 
 Occasionally we'll close issues if they appear stale or are too vague - please don't take this personally! Please feel free to re-open issues we've closed if there's something we've missed and they still need to be addressed.
 
@@ -16,15 +16,15 @@ Occasionally we'll close issues if they appear stale or are too vague - please d
 
 If you would like to start to fiddle with element's code, here is the flow we use.
 
-- Make a local clone of this repo: `git clone git@github.com:Juicy/juicy-redirect.git`
+- Make a local clone of this repo: `git clone git@github.com:Palindrom/palindrom-redirect.git`
 
 In order to develop it locally we suggest to use [polyserve](https://npmjs.com/polyserve) tool to handle bower paths gently.
 
-0. Go to the repo's directory: `cd juicy-redirect`
+0. Go to the repo's directory: `cd palindrom-redirect`
 1. Install [bower](http://bower.io/) & [polyserve](https://npmjs.com/polyserve): `$ npm install -g bower polyserve`
 2. Install local dependencies: `$ bower install`
 3. Start development server `$ polyserve -p 8000`
-4. Open the demo/preview: [http://localhost:8000/components/juicy-redirect/](http://localhost:8000/components/juicy-redirect/)
+4. Open the demo/preview: [http://localhost:8000/components/palindrom-redirect/](http://localhost:8000/components/palindrom-redirect/)
 
 ## Contributing Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# &lt;link is="palindrom-redirect"&gt;
+# &lt;palindrom-redirect&gt;
 
 > Custom Element that redirects to a new URL when an attribute is changed. It can be configured to work using window location or History API.
 
@@ -33,7 +33,7 @@ Or [download as ZIP](https://github.com/Palindrom/palindrom-redirect/archive/mas
 3. Start using it!
 
     ```html
-    <link is="palindrom-redirect" url="">
+    <palindrom-redirect url=""></palindrom-redirect>
     ```
 
 ## Attributes
@@ -43,7 +43,7 @@ Attribute      | Options            | Default  | Description
 `url`          | *String*           |          | Destination URL
 `url`          | `current`          |          | If a string `"current"` is provided as the URL, the component reloads the page
 `history`      |                    |          | If attribute `history` is present, the History API `pushState` is used instead of `window.location`
-`target`       | *String*           | `_self`  | Target where to open the link. Use `"_blank"` to open in new tab
+`target`       | *String*           | `_self`  | Target where to open the link. Use `"_blank"` to open in new tab.
 
 ## Events
 

--- a/index.html
+++ b/index.html
@@ -2,14 +2,14 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    <title>&lt;link is="puppet-redirect"&gt;</title>
+    <title>&lt;palindrom-redirect&gt;</title>
     <link rel="stylesheet" href="http://juicy.github.io/github-markdown-css/github-markdown.css">
 
     <!-- Importing Web Component's Polyfill (optional, allows to run it in old browsers) -->
-    <script src="https://cdn.jsdelivr.net/webcomponentsjs/0.7.19/webcomponents.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@1.0.22/webcomponents-lite.js"></script>
 
     <!-- Importing Custom Elements -->
-    <link rel="import" href="puppet-redirect.html">
+    <link rel="import" href="palindrom-redirect.html">
 
     <style>
         html {
@@ -25,7 +25,7 @@
 <body class="markdown-body">
 <a href="https://github.com/PuppetJs/puppet-redirect"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>
 
-<h1>&lt;link is="puppet-redirect"&gt;
+<h1>&lt;palindrom-redirect&gt;<s>&lt;link is="puppet-redirect"&gt;</s>
             <iframe src="http://ghbtns.com/github-btn.html?user=puppetjs&repo=puppet-redirect&type=watch&count=true&size=medium"
     allowtransparency="true" frameborder="0" scrolling="0" width="90" height="30"></iframe></h1>
 
@@ -36,9 +36,9 @@
 <p>See <a href="https://github.com/PuppetJs/puppet-redirect">README.md</a> for docs</p>
 
 <h2>Redirect using <code>window.location</code></h2>
-<button id="example1">&lt;link is="puppet-redirect" url="/"&gt;</button>
+<button id="example1">&lt;palindrom-redirect url="/"&gt;&lt;/palindrom-redirect&gt;</button>
 
-<link is="puppet-redirect" id="redirect1">
+<palindrom-redirect id="redirect1"></palindrom-redirect>
 
 <script>
     document.getElementById("example1").addEventListener("click", function () {
@@ -47,9 +47,9 @@
 </script>
 
 <h3>Open new tab</h3>
-<button id="example1_blank">&lt;link is="juicy-redirect" url="/" target="_blank"&gt;</button>
+<button id="example1_blank">&lt;palindrom-redirect url="/" target="_blank"&gt;&lt;/palindrom-redirect&gt;</button>
 
-<link is="juicy-redirect" id="redirect1_blank" target="_blank">
+<palindrom-redirect id="redirect1_blank" target="_blank"></palindrom-redirect>
 
 <script>
     document.getElementById("example1_blank").addEventListener("click", function () {
@@ -60,9 +60,9 @@
 <h2>Redirect using History API (<code>history.pushState</code>)</h2>
 <p>Watch console entries for events logging</p>
 
-<button id="example2">&lt;link is="puppet-redirect" history url="/"&gt;</button>
+<button id="example2">&lt;palindrom-redirect history url="/"&gt;&lt;/palindrom-redirect&gt;</button>
 
-<link is="puppet-redirect" history id="redirect2">
+<palindrom-redirect history id="redirect2"></palindrom-redirect>
 
 <script>
     document.getElementById("example2").addEventListener("click", function () {

--- a/palindrom-redirect.html
+++ b/palindrom-redirect.html
@@ -27,7 +27,6 @@
          * @property {String} url new URL
          */
         attributeChangedCallback(attributeName, oldVal, newVal) {
-            debugger
             switch(attributeName) {
                 case "url":
                     if(document.contains(this)){
@@ -50,7 +49,7 @@
                 history.pushState(null, null, url);
                 this.dispatchEvent(
                     new CustomEvent(
-                      `${this.localName}-pushstate`,
+                      'palindrom-redirect-pushstate',
                       {
                         "detail":{"url":url},
                         "bubbles": true

--- a/palindrom-redirect.html
+++ b/palindrom-redirect.html
@@ -1,29 +1,33 @@
 <!-- palindrom-redirect version: 0.7.0 | MIT License -->
-
 <script>
-    (function (global) {
-        var PalindromRedirectElementPrototype = Object.create(HTMLLinkElement.prototype);
+    customElements.define('palindrom-redirect', class PalindromRedirectElement extends HTMLElement{
+        static get observedAttributes() {
+            return ['url'];
+        }
 
-        PalindromRedirectElementPrototype.createdCallback = function(){
-            Object.defineProperty(this, 'url',{
-                set: function(val){
-                    this.setAttribute('url', val);
-                },
-                get: function(){
-                    return this.getAttribute('url');
-                }
-            })
-        };
+        set url(val){
+            if(val){
+                this.setAttribute('url', val);
+            } else {
+                this.removeAttribute('url');
+            }
+        }
+        get url(){
+            return this.getAttribute('url');
+        }
 
-        PalindromRedirectElementPrototype.attachedCallback = function(){
+        connectedCallback(){
+            // As we cannot customize `<link>`, let's pretend it's not visual
+            this.style.display = 'none';
             this.redirect( this.getAttribute("url") );
-        };
+        }
         /**
          * @event palindrom-redirect-pushstate
          * Called whenever `history.state` is changed.
          * @property {String} url new URL
          */
-        PalindromRedirectElementPrototype.attributeChangedCallback = function (attributeName, oldVal, newVal) {
+        attributeChangedCallback(attributeName, oldVal, newVal) {
+            debugger
             switch(attributeName) {
                 case "url":
                     if(document.contains(this)){
@@ -31,8 +35,8 @@
                     }
                     break;
             }
-        };
-        PalindromRedirectElementPrototype.redirect = function(url){
+        }
+        redirect(url){
             if(!url){
                 return false;
             }
@@ -46,7 +50,7 @@
                 history.pushState(null, null, url);
                 this.dispatchEvent(
                     new CustomEvent(
-                      `${this.getAttribute('is')}-pushstate`,
+                      `${this.localName}-pushstate`,
                       {
                         "detail":{"url":url},
                         "bubbles": true
@@ -60,24 +64,6 @@
             this.setAttribute("url", "");
             this.dispatchEvent(new CustomEvent('url-changed',{detail: ""}));
             return url;
-        };
-
-        global.PalindromRedirectElement = document.registerElement('palindrom-redirect', {
-            prototype: PalindromRedirectElementPrototype,
-            extends: "link"
-        });
-
-        /* backward compatibility */
-        var PuppetRedirectElementPrototype = Object.create(PalindromRedirectElementPrototype);
-        var originalAttachedCallback = PuppetRedirectElementPrototype.attachedCallback;
-        PuppetRedirectElementPrototype.attachedCallback = function() {            
-            console.warn('`puppet-redirect` has been renamed to `palindrom-redirect`, please update your markup, `puppet-redirect` will be removed soon');
-            originalAttachedCallback.bind(this)();
         }
-        global.PalindromRedirectElement = document.registerElement('puppet-redirect', {
-            prototype: PuppetRedirectElementPrototype,
-            extends: "link"
-        });
-        
-    })(window);
+    });
 </script>


### PR DESCRIPTION
Remove `puppet-redirect` backward compatibility layer.

Problem: it was not working with latest WebComponents.js polyfill

Required for https://github.com/Starcounter/StarcounterClientFiles/pull/22