### PR TITLE
Fix for fast redirection

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,12 @@
     "test",
     "wct.conf.json"
   ],
-  "dependencies": {},
+  "dependencies": {
+  },
+  "devDependencies": {
+    "web-component-tester": "^6.0.0",
+    "webcomponentsjs": "1.*.*"
+  },
   "authors": [
     "Marcin Warpechowski <marcin@nextgen.pl>",
     "Tomek Wytrebowicz <tomalecpub@gmail.com>"

--- a/palindrom-redirect.html
+++ b/palindrom-redirect.html
@@ -29,7 +29,7 @@
              * @property {String} url new URL
              */
             attributeChangedCallback(attributeName, oldVal, newVal) {
-                if (this.getRootNode().contains(this)) {
+                if (this.isConnected) {
                     this.redirect(newVal);
                 }
             }

--- a/test/spec-history.html
+++ b/test/spec-history.html
@@ -43,7 +43,7 @@
                 palRed.setAttribute('url', '/index.html');
             });
 
-            it('Should dispatch an event when url prop changes before the element is attached', function (done) {
+            it('When url prop changes before the element is attached, should dispatch an event once element is connected back', function (done) {
                 const parent = palRed.parentNode;
                 parent.removeChild(palRed);
                 palRed.addEventListener('palindrom-redirect-pushstate', ev => {
@@ -54,7 +54,7 @@
                 parent.appendChild(palRed);
             });
 
-            it('Should dispatch an event when url attribute changes before the element is attached', function (done) {
+            it('When url attribute changes before the element is attached, should dispatch an event once element is connected back', function (done) {
                 const parent = palRed.parentNode;
                 parent.removeChild(palRed);
                 palRed.addEventListener('palindrom-redirect-pushstate', ev => {
@@ -90,7 +90,7 @@
                     palRed.setAttribute('url', '/index.html');
                 });
 
-                it('Should dispatch a bubbling event when url prop changes before the element is attached', function (done) {
+                it('When url prop changes before the element is attached, should dispatch a bubbling event once element is connected back', function (done) {
                     const parent = palRed.parentNode;
                     parent.removeChild(palRed);
                     eventListener = ev => {
@@ -102,7 +102,7 @@
                     parent.appendChild(palRed);
                 });
 
-                it('Should dispatch a bubbling event when url attribute changes before the element is attached', function (done) {
+                it('When url attribute changes before the element is attached, should dispatch a bubbling event once element is connected back', function (done) {
                     const parent = palRed.parentNode;
                     parent.removeChild(palRed);
                     eventListener = ev => {

--- a/test/spec-history.html
+++ b/test/spec-history.html
@@ -42,6 +42,78 @@
                 });
                 palRed.setAttribute('url', '/index.html');
             });
+
+            it('Should dispatch an event when url prop changes before the element is attached', function (done) {
+                const parent = palRed.parentNode;
+                parent.removeChild(palRed);
+                palRed.addEventListener('palindrom-redirect-pushstate', ev => {
+                    expect(ev.detail.url).to.equal('/index.html');
+                    done();
+                });
+                palRed.url = '/index.html';
+                parent.appendChild(palRed);
+            });
+
+            it('Should dispatch an event when url attribute changes before the element is attached', function (done) {
+                const parent = palRed.parentNode;
+                parent.removeChild(palRed);
+                palRed.addEventListener('palindrom-redirect-pushstate', ev => {
+                    expect(ev.detail.url).to.equal('/index.html');
+                    done();
+                });
+                palRed.setAttribute('url', '/index.html');
+                parent.appendChild(palRed);
+            });
+
+            describe('event bubbling', () => {
+                let eventListener;
+
+                afterEach(function () {
+                    window.removeEventListener('palindrom-redirect-pushstate', eventListener);
+                });
+
+                it('Should dispatch a bubbling event when url prop changes', function (done) {
+                    eventListener = ev => {
+                        expect(ev.detail.url).to.equal('/index.html');
+                        done();
+                    };
+                    window.addEventListener('palindrom-redirect-pushstate', eventListener); 
+                    palRed.url = '/index.html';
+                });
+
+                it('Should dispatch a bubbling event when url attribute changes', function (done) {
+                    eventListener = ev => {
+                        expect(ev.detail.url).to.equal('/index.html');
+                        done();
+                    };
+                    window.addEventListener('palindrom-redirect-pushstate', eventListener); 
+                    palRed.setAttribute('url', '/index.html');
+                });
+
+                it('Should dispatch a bubbling event when url prop changes before the element is attached', function (done) {
+                    const parent = palRed.parentNode;
+                    parent.removeChild(palRed);
+                    eventListener = ev => {
+                        expect(ev.detail.url).to.equal('/index.html');
+                        done();
+                    };
+                    window.addEventListener('palindrom-redirect-pushstate', eventListener); 
+                    palRed.url = '/index.html';
+                    parent.appendChild(palRed);
+                });
+
+                it('Should dispatch a bubbling event when url attribute changes before the element is attached', function (done) {
+                    const parent = palRed.parentNode;
+                    parent.removeChild(palRed);
+                    eventListener = ev => {
+                        expect(ev.detail.url).to.equal('/index.html');
+                        done();
+                    };
+                    window.addEventListener('palindrom-redirect-pushstate', eventListener); 
+                    palRed.setAttribute('url', '/index.html');
+                    parent.appendChild(palRed);
+                });
+            });
         });
     });
 </script>


### PR DESCRIPTION
By "fast redirection", I mean a case in which Palindrom rapidly performs redirection twice. The second redirection URL is propagated to <palindrom-redirect> while the element is not yet connected to DOM. This resulted in the event not bubbling properly, therefore not being catched by "window.addEventListener" in PalindromDOM

Tested in Chrome, Firefox, Safari

This is a partial fix for Starcounter/HeadsOmni#293

------

Steps to reproduce the original problem:

1. Run BlendingEditor and SignIn, the versions used in Omni
2. Go to `/BlendingEditor/compositions`
3. You should be redirected to a sign in form
4. Provide your credentials and press "Sign in"
5. You should be redirected to `/BlendingEditor/compositions`

Actual:

You were redirected to a blank page.